### PR TITLE
Add simple floor plan example

### DIFF
--- a/indx.html
+++ b/indx.html
@@ -1,15 +1,21 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="./styles/reset.css">
     <link rel="stylesheet" href="./styles/styles.css">
-    <title>Document</title>
+    <title>Planta Baixa</title>
 </head>
 <body>
-    <div class="container">
-
+    <div class="floor-plan">
+        <div class="wall vertical"></div>
+        <div class="wall horizontal"></div>
+        <span class="label room-label" style="top:380px; left:260px;">Sala (5.8m x 7.6m)</span>
+        <span class="label room-label" style="top:140px; left:660px;">Quarto (3.6m x 3m)</span>
+        <span class="label room-label" style="top:520px; left:660px;">Banheiro (3.6m x 4.6m)</span>
+        <div class="measure horizontal" style="top:-15px;">10 m</div>
+        <div class="measure vertical" style="left:-15px;">8 m</div>
     </div>
 </body>
 </html>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,0 +1,65 @@
+/* Basic style for floor plan */
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    background: #f0f0f0;
+    padding: 20px;
+}
+
+.floor-plan {
+    position: relative;
+    width: 1000px;        /* 10m */
+    height: 800px;        /* 8m */
+    margin: 0 auto;
+    border: 20px solid #a0522d; /* 20cm brick thickness */
+    box-sizing: border-box;
+    background: #fff;
+}
+
+.wall {
+    position: absolute;
+    background: #a0522d;
+    z-index: 2;
+}
+
+.label {
+    position: absolute;
+    font-size: 14px;
+    background: rgba(255,255,255,0.8);
+    padding: 2px 4px;
+}
+/* Internal walls */
+.vertical {
+    width: 20px;          /* 20cm wall */
+    height: 760px;        /* interior height */
+    top: 0;
+    left: 580px;          /* 5.8m from left outer wall */
+}
+
+.horizontal {
+    width: 360px;         /* width of right column minus wall thickness */
+    height: 20px;
+    top: 300px;           /* 3m from top */
+    left: 580px;          /* aligned with vertical wall */
+}
+
+.room-label {
+    font-weight: bold;
+}
+
+.measure {
+    position: absolute;
+    font-size: 12px;
+    color: #000;
+}
+
+.measure.horizontal {
+    border-top: 1px dashed #000;
+    width: 100%;
+    left: 0;
+}
+
+.measure.vertical {
+    border-left: 1px dashed #000;
+    height: 100%;
+    top: 0;
+}


### PR DESCRIPTION
## Summary
- add CSS for base styles and wall layout
- create a floor plan example in `indx.html` with brick-sized walls
- include dimension markers for measurements

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686bd41d7f94832c88c608b6fced1fe9